### PR TITLE
feat: implement WebSocket presence functionality with user status tra…

### DIFF
--- a/Backend/build.gradle.kts
+++ b/Backend/build.gradle.kts
@@ -39,6 +39,7 @@ dependencies {
     
 	// Spring dependencies
     developmentOnly("org.springframework.boot:spring-boot-devtools")
+    implementation("org.springframework.boot:spring-boot-starter-websocket")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")

--- a/Backend/src/main/kotlin/com/transcendence/demo/DTO/Response/PresenceUserDTO.kt
+++ b/Backend/src/main/kotlin/com/transcendence/demo/DTO/Response/PresenceUserDTO.kt
@@ -1,0 +1,9 @@
+package com.transcendence.demo.DTO.Response
+
+data class PresenceUserDTO(
+    val id: Long,
+    val nickname: String,
+    val name: String,
+    val email: String,
+    val status: String = "online"
+)

--- a/Backend/src/main/kotlin/com/transcendence/demo/DTO/Response/PresenceUserDTO.kt
+++ b/Backend/src/main/kotlin/com/transcendence/demo/DTO/Response/PresenceUserDTO.kt
@@ -4,6 +4,5 @@ data class PresenceUserDTO(
     val id: Long,
     val nickname: String,
     val name: String,
-    val email: String,
     val status: String = "online"
 )

--- a/Backend/src/main/kotlin/com/transcendence/demo/config/SecurityConfig.kt
+++ b/Backend/src/main/kotlin/com/transcendence/demo/config/SecurityConfig.kt
@@ -37,6 +37,8 @@ class SecurityConfig(
 		"/auth/oauth2/authorize/google",
 		"/auth/oauth2/authorize/google/success",
 		"/auth/oauth2/authorize/google/failure",
+		"/ws",
+		"/ws/**",
 		"/error",
 		"/v3/api-docs/**",
 		"/swagger-ui/**",

--- a/Backend/src/main/kotlin/com/transcendence/demo/config/WebSocketConfig.kt
+++ b/Backend/src/main/kotlin/com/transcendence/demo/config/WebSocketConfig.kt
@@ -1,0 +1,31 @@
+package com.transcendence.demo.config
+
+import com.transcendence.demo.websocket.WebSocketPresenceHandler
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.socket.config.annotation.EnableWebSocket
+import org.springframework.web.socket.config.annotation.WebSocketConfigurer
+import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry
+
+@Configuration
+@EnableWebSocket
+class WebSocketConfig(
+    private val webSocketPresenceHandler: WebSocketPresenceHandler,
+    @Value("\${app.cors.allowed-origins:http://localhost:3000}")
+    private val corsAllowedOrigins: String
+) : WebSocketConfigurer {
+
+    override fun registerWebSocketHandlers(registry: WebSocketHandlerRegistry) {
+        registry
+            .addHandler(webSocketPresenceHandler, "/ws")
+            .setAllowedOrigins(*allowedOrigins())
+    }
+
+    private fun allowedOrigins(): Array<String> {
+        return corsAllowedOrigins
+            .split(",")
+            .map { it.trim() }
+            .filter { it.isNotBlank() }
+            .toTypedArray()
+    }
+}

--- a/Backend/src/main/kotlin/com/transcendence/demo/controller/PresenceController.kt
+++ b/Backend/src/main/kotlin/com/transcendence/demo/controller/PresenceController.kt
@@ -1,0 +1,26 @@
+package com.transcendence.demo.controller
+
+import com.transcendence.demo.DTO.Response.PresenceUserDTO
+import com.transcendence.demo.websocket.PresenceService
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/presence")
+class PresenceController(
+    private val presenceService: PresenceService
+) {
+    @GetMapping("/online-users")
+    fun onlineUsers(): ResponseEntity<Map<String, Any>> {
+        val onlineUsers: List<PresenceUserDTO> = presenceService.getOnlineUsers()
+        return ResponseEntity.ok(
+            mapOf(
+                "success" to true,
+                "onlineUsers" to onlineUsers,
+                "count" to onlineUsers.size
+            )
+        )
+    }
+}

--- a/Backend/src/main/kotlin/com/transcendence/demo/entity/User.kt
+++ b/Backend/src/main/kotlin/com/transcendence/demo/entity/User.kt
@@ -35,6 +35,9 @@ data class User(
     @Column(nullable = false)
     var profilePic: Int = 0,
 
+    @Column(name = "status", nullable = false)
+    var status: String = "offline",
+
     @Column(name = "two_factor_enabled", nullable = false)
     var twoFactorEnabled: Boolean = false,
 

--- a/Backend/src/main/kotlin/com/transcendence/demo/websocket/PresenceService.kt
+++ b/Backend/src/main/kotlin/com/transcendence/demo/websocket/PresenceService.kt
@@ -1,0 +1,83 @@
+package com.transcendence.demo.websocket
+
+import com.transcendence.demo.DTO.Response.PresenceUserDTO
+import com.transcendence.demo.entity.User
+import com.transcendence.demo.repository.UserRepository
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import java.util.concurrent.ConcurrentHashMap
+
+@Service
+class PresenceService(
+    private val userRepository: UserRepository
+) {
+    private val logger = LoggerFactory.getLogger(PresenceService::class.java)
+    private val userSessions = ConcurrentHashMap<Long, MutableSet<String>>()
+    private val sessionUsers = ConcurrentHashMap<String, Long>()
+
+    fun registerConnection(user: User, sessionId: String): Boolean {
+        val userId = requireNotNull(user.id) { "User id is required for presence tracking" }
+        val sessions = userSessions.computeIfAbsent(userId) { ConcurrentHashMap.newKeySet() }
+        val wasOffline = sessions.isEmpty()
+
+        sessions.add(sessionId)
+        sessionUsers[sessionId] = userId
+
+        if (wasOffline) {
+            updateUserStatus(user, "online")
+            logger.info("User {} is now online", userId)
+        }
+
+        return wasOffline
+    }
+
+    fun unregisterConnection(sessionId: String): Long? {
+        val userId = sessionUsers.remove(sessionId) ?: return null
+        val sessions = userSessions[userId] ?: return userId
+
+        sessions.remove(sessionId)
+        if (sessions.isEmpty()) {
+            userSessions.remove(userId)
+            userRepository.findById(userId).ifPresent { user ->
+                updateUserStatus(user, "offline")
+                logger.info("User {} is now offline", userId)
+            }
+        }
+
+        return userId
+    }
+
+    fun getOnlineUsers(): List<PresenceUserDTO> {
+        val onlineIds = userSessions.keys.toList()
+        if (onlineIds.isEmpty()) {
+            return emptyList()
+        }
+
+        return userRepository.findAllById(onlineIds).map { user ->
+            user.toPresenceDto()
+        }.sortedBy { it.nickname.lowercase() }
+    }
+
+    fun isOnline(userId: Long): Boolean {
+        return userSessions[userId]?.isNotEmpty() == true
+    }
+
+    private fun updateUserStatus(user: User, status: String) {
+        if (user.status == status) {
+            return
+        }
+
+        user.status = status
+        userRepository.save(user)
+    }
+
+    private fun User.toPresenceDto(): PresenceUserDTO {
+        return PresenceUserDTO(
+            id = id!!,
+            nickname = nickname,
+            name = name,
+            email = email,
+            status = status
+        )
+    }
+}

--- a/Backend/src/main/kotlin/com/transcendence/demo/websocket/WebSocketEventDTO.kt
+++ b/Backend/src/main/kotlin/com/transcendence/demo/websocket/WebSocketEventDTO.kt
@@ -1,0 +1,14 @@
+package com.transcendence.demo.websocket
+
+import com.transcendence.demo.DTO.Response.PresenceUserDTO
+import java.time.Instant
+
+data class WebSocketEventDTO(
+    val type: String,
+    val event: String,
+    val userId: Long? = null,
+    val message: String? = null,
+    val onlineUsers: List<PresenceUserDTO> = emptyList(),
+    val timestamp: Instant = Instant.now(),
+    val error: String? = null
+)

--- a/Backend/src/main/kotlin/com/transcendence/demo/websocket/WebSocketIncomingMessageDTO.kt
+++ b/Backend/src/main/kotlin/com/transcendence/demo/websocket/WebSocketIncomingMessageDTO.kt
@@ -1,0 +1,6 @@
+package com.transcendence.demo.websocket
+
+data class WebSocketIncomingMessageDTO(
+    val type: String? = null,
+    val message: String? = null
+)

--- a/Backend/src/main/kotlin/com/transcendence/demo/websocket/WebSocketPresenceHandler.kt
+++ b/Backend/src/main/kotlin/com/transcendence/demo/websocket/WebSocketPresenceHandler.kt
@@ -54,11 +54,8 @@ class WebSocketPresenceHandler(
                 onlineUsers = presenceService.getOnlineUsers()
             )
 
-            sendEvent(
-                session,
-                presenceEvent
-            )
-            broadcastEvent(presenceEvent)
+            sendEvent(session, presenceEvent)
+            broadcastEventExcluding(presenceEvent, session.id)
         } catch (ex: Exception) {
             logger.warn("WebSocket connection rejected: {}", ex.message)
             safeSendError(session, ex.message ?: "Connection rejected")
@@ -133,6 +130,16 @@ class WebSocketPresenceHandler(
         sessions.values.forEach { session ->
             runCatching {
                 sendEvent(session, event)
+            }
+        }
+    }
+
+    private fun broadcastEventExcluding(event: WebSocketEventDTO, excludeSessionId: String) {
+        sessions.values.forEach { session ->
+            if (session.id != excludeSessionId) {
+                runCatching {
+                    sendEvent(session, event)
+                }
             }
         }
     }

--- a/Backend/src/main/kotlin/com/transcendence/demo/websocket/WebSocketPresenceHandler.kt
+++ b/Backend/src/main/kotlin/com/transcendence/demo/websocket/WebSocketPresenceHandler.kt
@@ -1,0 +1,164 @@
+package com.transcendence.demo.websocket
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.databind.SerializationFeature
+import com.transcendence.demo.providers.JwtTokenGenerator
+import com.transcendence.demo.repository.UserRepository
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+import org.springframework.web.socket.CloseStatus
+import org.springframework.web.socket.TextMessage
+import org.springframework.web.socket.WebSocketSession
+import org.springframework.web.socket.handler.TextWebSocketHandler
+import org.springframework.web.util.UriComponentsBuilder
+import java.util.concurrent.ConcurrentHashMap
+
+@Component
+class WebSocketPresenceHandler(
+    private val jwtTokenGenerator: JwtTokenGenerator,
+    private val userRepository: UserRepository,
+    private val presenceService: PresenceService
+) : TextWebSocketHandler() {
+    private val logger = LoggerFactory.getLogger(WebSocketPresenceHandler::class.java)
+    private val sessions = ConcurrentHashMap<String, WebSocketSession>()
+    private val objectMapper = jacksonObjectMapper()
+        .registerModule(JavaTimeModule())
+        .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+
+    override fun afterConnectionEstablished(session: WebSocketSession) {
+        try {
+            val token = extractToken(session)
+                ?: throw IllegalArgumentException("Missing token")
+
+            if (!jwtTokenGenerator.isAccessTokenValid(token)) {
+                throw IllegalArgumentException("Invalid token")
+            }
+
+            val userId = jwtTokenGenerator.extractUserId(token)
+                ?: throw IllegalArgumentException("User id not found")
+
+            val user = userRepository.findById(userId).orElse(null)
+                ?: throw IllegalArgumentException("User not found")
+
+            session.attributes["userId"] = userId
+            session.attributes["email"] = user.email
+            sessions[session.id] = session
+            val becameOnline = presenceService.registerConnection(user, session.id)
+
+            logger.info("WebSocket connected: session={}, userId={}", session.id, userId)
+            val presenceEvent = WebSocketEventDTO(
+                type = "presence",
+                event = if (becameOnline) "online" else "connected",
+                userId = userId,
+                onlineUsers = presenceService.getOnlineUsers()
+            )
+
+            sendEvent(
+                session,
+                presenceEvent
+            )
+            broadcastEvent(presenceEvent)
+        } catch (ex: Exception) {
+            logger.warn("WebSocket connection rejected: {}", ex.message)
+            safeSendError(session, ex.message ?: "Connection rejected")
+            closeQuietly(session, CloseStatus.POLICY_VIOLATION)
+        }
+    }
+
+    override fun handleTextMessage(session: WebSocketSession, message: TextMessage) {
+        val userId = session.attributes["userId"] as? Long
+        if (userId == null) {
+            safeSendError(session, "Unauthenticated session")
+            closeQuietly(session, CloseStatus.POLICY_VIOLATION)
+            return
+        }
+
+        try {
+            val payload = objectMapper.readValue(message.payload, WebSocketIncomingMessageDTO::class.java)
+            logger.info("WebSocket message received from userId={}: {}", userId, payload.message)
+
+            sendEvent(
+                session,
+                WebSocketEventDTO(
+                    type = "message",
+                    event = "received",
+                    userId = userId,
+                    message = payload.message ?: ""
+                )
+            )
+        } catch (ex: Exception) {
+            logger.warn("Invalid WebSocket payload for session {}: {}", session.id, ex.message)
+            safeSendError(session, "Invalid JSON payload")
+        }
+    }
+
+    override fun afterConnectionClosed(session: WebSocketSession, status: CloseStatus) {
+        val userId = presenceService.unregisterConnection(session.id)
+        sessions.remove(session.id)
+        if (userId != null) {
+            logger.info("WebSocket disconnected: session={}, userId={}, status={}", session.id, userId, status.code)
+            broadcastEvent(
+                WebSocketEventDTO(
+                    type = "presence",
+                    event = "offline",
+                    userId = userId,
+                    onlineUsers = presenceService.getOnlineUsers()
+                )
+            )
+        } else {
+            logger.info("WebSocket disconnected: session={}, status={}", session.id, status.code)
+        }
+    }
+
+    override fun handleTransportError(session: WebSocketSession, exception: Throwable) {
+        logger.warn("WebSocket transport error for session {}: {}", session.id, exception.message)
+        safeSendError(session, "Transport error")
+    }
+
+    private fun extractToken(session: WebSocketSession): String? {
+        val uri = session.uri ?: return null
+        return UriComponentsBuilder.fromUri(uri).build().queryParams.getFirst("token")?.trim()
+    }
+
+    private fun sendEvent(session: WebSocketSession, event: WebSocketEventDTO) {
+        if (!session.isOpen) {
+            return
+        }
+
+        session.sendMessage(TextMessage(objectMapper.writeValueAsString(event)))
+    }
+
+    private fun broadcastEvent(event: WebSocketEventDTO) {
+        sessions.values.forEach { session ->
+            runCatching {
+                sendEvent(session, event)
+            }
+        }
+    }
+
+    private fun safeSendError(session: WebSocketSession, message: String) {
+        if (!session.isOpen) {
+            return
+        }
+
+        runCatching {
+            sendEvent(
+                session,
+                WebSocketEventDTO(
+                    type = "error",
+                    event = "error",
+                    error = message
+                )
+            )
+        }
+    }
+
+    private fun closeQuietly(session: WebSocketSession, closeStatus: CloseStatus) {
+        runCatching {
+            if (session.isOpen) {
+                session.close(closeStatus)
+            }
+        }
+    }
+}


### PR DESCRIPTION
This pull request introduces real-time user presence tracking via WebSocket integration in the backend. It adds a WebSocket endpoint for authenticated clients, manages online/offline user status, and exposes an API to retrieve currently online users. The changes also include updates to the user entity and security configuration to support these features.

**WebSocket Presence Tracking**

* Introduced `WebSocketPresenceHandler` to handle authenticated WebSocket connections, broadcast presence events, and manage session lifecycle, including token validation and error handling.
* Added `PresenceService` to track user sessions, update user online/offline status in the database, and provide a list of online users.
* Defined DTOs for presence and event communication over WebSocket: `PresenceUserDTO`, `WebSocketEventDTO`, and `WebSocketIncomingMessageDTO`.

**API and Configuration**

* Added `PresenceController` with a `/presence/online-users` endpoint to return the list of online users and their count.
* Created `WebSocketConfig` to register the `/ws` WebSocket endpoint and configure CORS origins.
* Updated security rules to allow unauthenticated access to `/ws` endpoints.
* Added the `spring-boot-starter-websocket` dependency to enable WebSocket support.

**User Entity Enhancement**

* Added a `status` field to the `User` entity to persist online/offline state and presence notifications