### PR TITLE
feat: implement profile update functionality with validation

### DIFF
--- a/Backend/src/main/kotlin/com/transcendence/demo/DTO/Request/ProfileUpdateRequestDTO.kt
+++ b/Backend/src/main/kotlin/com/transcendence/demo/DTO/Request/ProfileUpdateRequestDTO.kt
@@ -1,0 +1,7 @@
+package com.transcendence.demo.DTO.Request
+
+data class ProfileUpdateRequestDTO(
+    val name: String? = null,
+    val nickname: String? = null,
+    val profilePic: Int? = null
+)

--- a/Backend/src/main/kotlin/com/transcendence/demo/DTO/Response/UserResponseDTO.kt
+++ b/Backend/src/main/kotlin/com/transcendence/demo/DTO/Response/UserResponseDTO.kt
@@ -4,5 +4,6 @@ data class UserResponseDTO(
     val id: Long? = null,
     val nickname: String = "",
     val name: String = "",
-    val email: String = ""
+    val email: String = "",
+    val profilePic: Int = 0
 )

--- a/Backend/src/main/kotlin/com/transcendence/demo/controller/ProfileController.kt
+++ b/Backend/src/main/kotlin/com/transcendence/demo/controller/ProfileController.kt
@@ -1,7 +1,6 @@
 package com.transcendence.demo.controller
 
 import com.transcendence.demo.DTO.Request.ProfileUpdateRequestDTO
-import com.transcendence.demo.DTO.Response.UserResponseDTO
 import com.transcendence.demo.service.UserService
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.security.SecurityRequirement

--- a/Backend/src/main/kotlin/com/transcendence/demo/controller/ProfileController.kt
+++ b/Backend/src/main/kotlin/com/transcendence/demo/controller/ProfileController.kt
@@ -1,0 +1,72 @@
+package com.transcendence.demo.controller
+
+import com.transcendence.demo.DTO.Request.ProfileUpdateRequestDTO
+import com.transcendence.demo.DTO.Response.UserResponseDTO
+import com.transcendence.demo.service.UserService
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.security.SecurityRequirement
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.Authentication
+import org.springframework.security.oauth2.core.user.OAuth2User
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/profile")
+class ProfileController(
+    private val userService: UserService
+) {
+    @Operation(
+        summary = "Atualiza o perfil do usuario autenticado",
+        security = [SecurityRequirement(name = "bearerAuth")]
+    )
+    @PatchMapping("/me")
+    fun updateMyProfile(
+        @RequestBody request: ProfileUpdateRequestDTO,
+        authentication: Authentication?
+    ): ResponseEntity<Any> {
+        if (authentication == null || !authentication.isAuthenticated) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                .body(mapOf("success" to false, "message" to "Unauthorized"))
+        }
+
+        val email = resolveEmail(authentication)
+            ?: return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                .body(mapOf("success" to false, "message" to "User email not found in token"))
+
+        return try {
+            val updatedProfile = userService.updateProfile(email, request)
+            ResponseEntity.ok(
+                mapOf(
+                    "success" to true,
+                    "user" to updatedProfile
+                )
+            )
+        } catch (ex: IllegalArgumentException) {
+            ResponseEntity.badRequest().body(
+                mapOf(
+                    "success" to false,
+                    "message" to ex.message.orEmpty()
+                )
+            )
+        } catch (ex: NoSuchElementException) {
+            ResponseEntity.status(HttpStatus.NOT_FOUND).body(
+                mapOf(
+                    "success" to false,
+                    "message" to ex.message.orEmpty()
+                )
+            )
+        }
+    }
+
+    private fun resolveEmail(authentication: Authentication): String? {
+        return when (val principal = authentication.principal) {
+            is OAuth2User -> principal.getAttribute<String>("email")
+            is String -> principal
+            else -> null
+        }
+    }
+}

--- a/Backend/src/main/kotlin/com/transcendence/demo/controller/ProfileController.kt
+++ b/Backend/src/main/kotlin/com/transcendence/demo/controller/ProfileController.kt
@@ -19,7 +19,7 @@ class ProfileController(
     private val userService: UserService
 ) {
     @Operation(
-        summary = "Atualiza o perfil do usuario autenticado",
+        summary = "Atualiza o perfil do usuário autenticado",
         security = [SecurityRequirement(name = "bearerAuth")]
     )
     @PatchMapping("/me")

--- a/Backend/src/main/kotlin/com/transcendence/demo/service/UserService.kt
+++ b/Backend/src/main/kotlin/com/transcendence/demo/service/UserService.kt
@@ -1,6 +1,7 @@
 package com.transcendence.demo.service
 
 import com.transcendence.demo.DTO.Request.RegisterRequestDTO
+import com.transcendence.demo.DTO.Request.ProfileUpdateRequestDTO
 import com.transcendence.demo.DTO.Request.TwoFactorDisableRequestDTO
 import com.transcendence.demo.DTO.Request.TwoFactorSetupConfirmRequestDTO
 import com.transcendence.demo.DTO.Response.LoginResponseDTO
@@ -22,6 +23,11 @@ class UserService(
     private val jwtTokenGenerator: JwtTokenGenerator,
     private val twoFactorService: TwoFactorService
 ) {
+
+    companion object {
+        private const val MIN_PROFILE_PIC_INDEX = 0
+        private const val MAX_PROFILE_PIC_INDEX = 15
+    }
 
     private val passwordEncoder = BCryptPasswordEncoder()
 
@@ -61,9 +67,51 @@ class UserService(
             email = request.email,
             username = request.nickname,
             passwordHash = encryptedPassword,
-        
+            profilePic = 0
         )
         return userRepository.save(user)
+    }
+
+    fun updateProfile(email: String, request: ProfileUpdateRequestDTO): UserResponseDTO {
+        val user = userRepository.findByEmail(email)
+            ?: throw NoSuchElementException("User not found")
+
+        request.name?.let { value ->
+            val normalizedName = value.trim()
+            if (normalizedName.isBlank()) {
+                throw IllegalArgumentException("Name cannot be blank")
+            }
+            user.name = normalizedName
+        }
+
+        request.nickname?.let { value ->
+            val normalizedNickname = value.trim()
+            if (normalizedNickname.isBlank()) {
+                throw IllegalArgumentException("Nickname cannot be blank")
+            }
+
+            val nicknameOwner = userRepository.findByNickname(normalizedNickname)
+            if (nicknameOwner != null && nicknameOwner.id != user.id) {
+                throw IllegalArgumentException("Nickname already exists")
+            }
+
+            val usernameOwner = userRepository.findByUsername(normalizedNickname)
+            if (usernameOwner != null && usernameOwner.id != user.id) {
+                throw IllegalArgumentException("Username already exists")
+            }
+
+            user.nickname = normalizedNickname
+            user.username = normalizedNickname
+        }
+
+        request.profilePic?.let { value ->
+            if (value !in MIN_PROFILE_PIC_INDEX..MAX_PROFILE_PIC_INDEX) {
+                throw IllegalArgumentException("Profile picture must be between $MIN_PROFILE_PIC_INDEX and $MAX_PROFILE_PIC_INDEX")
+            }
+            user.profilePic = value
+        }
+
+        return userRepository.save(user).toUserResponseDto()
     }
 
     fun loginUser(email: String, password: String): LoginResponseDTO {
@@ -78,12 +126,7 @@ class UserService(
                     message = "2FA required",
                     twoFactorToken = tempToken,
                     requiresTwoFactor = true,
-                    user = UserResponseDTO(
-                        id = user.id,
-                        nickname = user.nickname,
-                        name = user.name,
-                        email = user.email
-                    )
+                    user = user.toUserResponseDto()
                 )
             } else {
                 val token = jwtTokenGenerator.generateToken(user.id!!, user.email)
@@ -91,12 +134,7 @@ class UserService(
                     success = true,
                     message = "Login successful",
                     token = token,
-                    user = UserResponseDTO(
-                        id = user.id,
-                        nickname = user.nickname,
-                        name = user.name,
-                        email = user.email
-                    )
+                    user = user.toUserResponseDto()
                 )
             }
         } else {
@@ -124,12 +162,7 @@ class UserService(
             success = true,
             message = "Login successful",
             token = finalToken,
-            user = UserResponseDTO(
-                id = user.id,
-                nickname = user.nickname,
-                name = user.name,
-                email = user.email
-            )
+            user = user.toUserResponseDto()
         )
     }
 
@@ -248,23 +281,13 @@ class UserService(
             success = true,
             message = "Google login successful",
             token = token,
-            user = UserResponseDTO(
-                id = user.id,
-                nickname = user.nickname,
-                name = user.name,
-                email = user.email
-            )
+            user = user.toUserResponseDto()
         )
     }
 
     fun getUserProfileByEmail(email: String): UserResponseDTO? {
         val user = userRepository.findByEmail(email) ?: return null
-        return UserResponseDTO(
-            id = user.id,
-            nickname = user.nickname,
-            name = user.name,
-            email = user.email
-        )
+        return user.toUserResponseDto()
     }
 
     private fun createGoogleUser(email: String, name: String?): User {
@@ -310,5 +333,15 @@ class UserService(
      */
     private fun isValidEmail(email: String): Boolean {
         return email.contains("@") && email.contains(".")
+    }
+
+    private fun User.toUserResponseDto(): UserResponseDTO {
+        return UserResponseDTO(
+            id = id,
+            nickname = nickname,
+            name = name,
+            email = email,
+            profilePic = profilePic
+        )
     }
 }


### PR DESCRIPTION
This pull request introduces support for updating a user's profile, including name, nickname, and profile picture, via a new API endpoint. It also refactors the user response logic to consistently include the `profilePic` field and centralizes response creation. The most important changes are summarized below:

**Profile Update Feature:**

* Added `ProfileController` with a new PATCH endpoint `/profile/me` allowing authenticated users to update their name, nickname, and profile picture. Includes validation and error handling for unauthorized access and invalid data.
* Introduced `ProfileUpdateRequestDTO` to encapsulate profile update requests with optional fields for `name`, `nickname`, and `profilePic`.
* Implemented `UserService.updateProfile` method to handle profile updates, including validation for name, nickname uniqueness, and profile picture index bounds. 

**User Response Consistency:**

* Updated `UserResponseDTO` to include a `profilePic` field, ensuring clients always receive the user's profile picture index.
* Centralized the creation of `UserResponseDTO` in a new extension function `User.toUserResponseDto()`, and refactored service methods to use it for consistent responses.