### PR TITLE
feat: integraçaologin OAUTH com o front

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,7 @@ SSL_KEYSTORE_PATH=file:/app/certs/keystore-prod.p12
 # CORS (backend) - origins permitidos
 APP_CORS_ALLOWED_ORIGINS_DEV=http://localhost:3000
 APP_CORS_ALLOWED_ORIGINS_PROD=http://localhost:8080
+
+# Frontend base URL for OAuth2 redirects (backend -> frontend)
+APP_FRONTEND_BASE_URL_DEV=http://localhost:3000
+APP_FRONTEND_BASE_URL_PROD=http://localhost:8080

--- a/Backend/src/main/kotlin/com/transcendence/demo/controller/AuthController.kt
+++ b/Backend/src/main/kotlin/com/transcendence/demo/controller/AuthController.kt
@@ -16,6 +16,7 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import jakarta.servlet.http.Cookie
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.Authentication
@@ -34,6 +35,9 @@ class AuthController(
     private val userService: UserService,
     private val jwtTokenGenerator: JwtTokenGenerator
 ) {
+
+    @Value("\${app.frontend.base-url:http://localhost:3000}")
+    private lateinit var frontendBaseUrl: String
     @PostMapping("/register")
     fun registerUser(@RequestBody request: RegisterRequestDTO): ResponseEntity<String> {
         val (success, message) = userService.registerUser(request)
@@ -181,44 +185,55 @@ class AuthController(
     }
 
     @GetMapping("/oauth2/authorize/google/success")
-    fun oauthGoogleSuccess(authentication: Authentication?): ResponseEntity<LoginResponseDTO> {
+    fun oauthGoogleSuccess(
+        authentication: Authentication?,
+        response: HttpServletResponse
+    ) {
         if (authentication == null || !authentication.isAuthenticated) {
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                .body(LoginResponseDTO(success = false, message = "OAuth2 authentication not found"))
+            response.sendRedirect("$frontendBaseUrl/?oauthError=oauth2_authentication_not_found")
+            return
         }
 
         val oauthAuthentication = authentication as? OAuth2AuthenticationToken
-            ?: return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                .body(LoginResponseDTO(success = false, message = "Invalid OAuth2 authentication type"))
+        if (oauthAuthentication == null) {
+            response.sendRedirect("$frontendBaseUrl/?oauthError=invalid_oauth2_type")
+            return
+        }
 
         if (oauthAuthentication.authorizedClientRegistrationId != "google") {
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                .body(LoginResponseDTO(success = false, message = "Invalid OAuth2 provider"))
+            response.sendRedirect("$frontendBaseUrl/?oauthError=invalid_provider")
+            return
         }
 
         val principal = oauthAuthentication.principal as? OAuth2User
-            ?: return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                .body(LoginResponseDTO(success = false, message = "OAuth2 principal not found"))
+        if (principal == null) {
+            response.sendRedirect("$frontendBaseUrl/?oauthError=principal_not_found")
+            return
+        }
 
         val email = principal.getAttribute<String>("email")
         val name = principal.getAttribute<String>("name")
         val emailVerified = parseEmailVerified(principal.getAttribute<Any>("email_verified"))
 
         if (!emailVerified) {
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                .body(LoginResponseDTO(success = false, message = "Google account email is not verified"))
+            response.sendRedirect("$frontendBaseUrl/?oauthError=email_not_verified")
+            return
         }
 
         if (email.isNullOrBlank()) {
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                .body(LoginResponseDTO(success = false, message = "Google account email not found"))
+            response.sendRedirect("$frontendBaseUrl/?oauthError=email_not_found")
+            return
         }
 
-        val response = userService.loginOrCreateGoogleUser(email, name)
-        return if (response.success) {
-            ResponseEntity.ok(response)
+        val loginResponse = userService.loginOrCreateGoogleUser(email, name)
+        if (loginResponse.success && loginResponse.token != null) {
+            response.sendRedirect("$frontendBaseUrl/?token=${loginResponse.token}")
         } else {
-            ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(response)
+            val encodedMessage = java.net.URLEncoder.encode(
+                loginResponse.message,
+                java.nio.charset.StandardCharsets.UTF_8
+            )
+            response.sendRedirect("$frontendBaseUrl/?oauthError=$encodedMessage")
         }
     }
 

--- a/Backend/src/main/kotlin/com/transcendence/demo/security/OAuth2AuthenticationFailureHandler.kt
+++ b/Backend/src/main/kotlin/com/transcendence/demo/security/OAuth2AuthenticationFailureHandler.kt
@@ -7,12 +7,16 @@ import org.springframework.security.oauth2.core.OAuth2AuthenticationException
 import org.springframework.security.web.RedirectStrategy
 import org.springframework.security.web.authentication.AuthenticationFailureHandler
 import org.springframework.security.web.DefaultRedirectStrategy
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
 
 @Component
 class OAuth2AuthenticationFailureHandler : AuthenticationFailureHandler {
+
+	@Value("\${app.frontend.base-url:http://localhost:3000}")
+	private lateinit var frontendBaseUrl: String
 
 	private val redirectStrategy: RedirectStrategy = DefaultRedirectStrategy()
 
@@ -28,10 +32,10 @@ class OAuth2AuthenticationFailureHandler : AuthenticationFailureHandler {
 			?: "OAuth2 authentication failed"
 
 		val targetUrl = buildString {
-			append("/auth/oauth2/authorize/google/failure")
-			append("?error=")
+			append(frontendBaseUrl)
+			append("/?oauthError=")
 			append(urlEncode(errorCode))
-			append("&error_description=")
+			append("&oauthErrorDescription=")
 			append(urlEncode(description))
 		}
 

--- a/Backend/src/main/resources/application-dev.properties
+++ b/Backend/src/main/resources/application-dev.properties
@@ -18,6 +18,9 @@ server.ssl.key-alias=${SSL_KEY_ALIAS:transcendence-dev}
 # CORS (dev)
 app.cors.allowed-origins=${APP_CORS_ALLOWED_ORIGINS:http://localhost:3000}
 
+# Frontend base URL for OAuth2 redirects
+app.frontend.base-url=${APP_FRONTEND_BASE_URL:http://localhost:3000}
+
 #OAUTH Google
 spring.security.oauth2.client.registration.google.client-id=${GOOGLE_CLIENT_ID:}
 spring.security.oauth2.client.registration.google.client-secret=${GOOGLE_CLIENT_SECRET:}

--- a/Backend/src/main/resources/application-prod.properties
+++ b/Backend/src/main/resources/application-prod.properties
@@ -9,3 +9,6 @@ server.ssl.key-alias=${SSL_KEY_ALIAS:transcendence-prod}
 
 # CORS (prod): origem do frontend no host/compose
 app.cors.allowed-origins=${APP_CORS_ALLOWED_ORIGINS:http://localhost:8080}
+
+# Frontend base URL for OAuth2 redirects
+app.frontend.base-url=${APP_FRONTEND_BASE_URL:http://localhost:8080}

--- a/Frontend/src/App.jsx
+++ b/Frontend/src/App.jsx
@@ -230,6 +230,24 @@ function App() {
       return;
     }
 
+    const urlParams = new URLSearchParams(window.location.search);
+    const oauthToken = urlParams.get('token');
+    const oauthError = urlParams.get('oauthError');
+
+    if (oauthToken) {
+      localStorage.setItem('transcendence_token', oauthToken);
+      window.history.replaceState({}, '', window.location.pathname);
+      syncProfileFromToken('home');
+      return;
+    }
+
+    if (oauthError) {
+      setError(decodeURIComponent(oauthError));
+      window.history.replaceState({}, '', window.location.pathname);
+      setView('login');
+      return;
+    }
+
     syncProfileFromToken('home');
   }, [syncProfileFromToken]);
 
@@ -296,20 +314,7 @@ function App() {
 
   const handleGoogleLogin = () => {
     setError('');
-    // Google login flow not implemented: keep simulated fallback
-    const nextProfile = {
-      name: 'google player',
-      nickname: 'google player',
-      email: 'google.player@gmail.com',
-      bio: 'Player ready to start the journey.',
-      avatarUrl: ''
-    };
-
-    setProfile(nextProfile);
-    setProfileForm(nextProfile);
-    localStorage.setItem('transcendence_profile', JSON.stringify(nextProfile));
-    setView('home');
-    setLoginForm({ email: '', password: '' });
+    window.location.href = api.getGoogleOAuthUrl();
   };
 
   const handleGoToRegister = () => {

--- a/Frontend/src/services/api.js
+++ b/Frontend/src/services/api.js
@@ -127,6 +127,10 @@ export function setHttpErrorHandler(fn) {
   httpErrorHandler = typeof fn === 'function' ? fn : null;
 }
 
+export function getGoogleOAuthUrl() {
+  return `${API_BASE}/auth/oauth2/authorize/google`;
+}
+
 export async function updateProfile(token, data) {
   try {
     const res = await fetch(`${API_BASE}/profile/me`, {
@@ -235,7 +239,8 @@ const api = {
   searchUsers,
   sendFriendRequest,
   acceptFriendRequest,
-  rejectFriendRequest
+  rejectFriendRequest,
+  getGoogleOAuthUrl
 };
 
 export default api;


### PR DESCRIPTION
This pull request implements a complete OAuth2 login flow with Google, integrating both backend and frontend to support seamless authentication and error handling. The backend now redirects users to the frontend with either a token or error messages after OAuth2 authentication, and the frontend processes these responses to update the UI or handle errors accordingly. Additionally, configuration options for frontend URLs are added to both backend and environment files to support different deployment environments.

**Backend: OAuth2 Redirect and Configuration**

- The backend now redirects to the frontend with either a token or an error message upon OAuth2 authentication success or failure, instead of returning JSON responses. This ensures a user-friendly flow and allows the frontend to handle login state and errors directly. [[1]](diffhunk://#diff-57a13c83529122df0618ba2d02264504e37128d5510bf5369a2f46cce3bb2e5cL184-R236) [[2]](diffhunk://#diff-7477fe944ec6580422c4e2ebd7afe550d61c87b2978e9c5a9e2bd707a427c9bdL31-R38)
- Introduced a configurable `app.frontend.base-url` property (with environment variable support) for OAuth2 redirects, added to both `application-dev.properties` and `application-prod.properties`, and referenced in the controller and failure handler. [[1]](diffhunk://#diff-650446128f62d4f2293262c915cd9154abc09aa4b1337c5b06708bf3d6d29106R21-R23) [[2]](diffhunk://#diff-6bddbda03c589a9a36b3a3c4db7ab7b1bc07245873e593c3566739db49e1e91eR12-R14) [[3]](diffhunk://#diff-57a13c83529122df0618ba2d02264504e37128d5510bf5369a2f46cce3bb2e5cR38-R40) [[4]](diffhunk://#diff-7477fe944ec6580422c4e2ebd7afe550d61c87b2978e9c5a9e2bd707a427c9bdR10-R20)
- Updated `.env.example` to include new frontend base URL variables for development and production environments.

**Frontend: OAuth2 Login Flow Handling**

- The frontend now parses the URL for `token` or `oauthError` parameters after OAuth2 redirect, storing the token and updating the UI or displaying errors as appropriate.
- The Google login button now initiates the OAuth2 flow by redirecting to the backend's Google OAuth2 authorization endpoint instead of using a simulated login. [[1]](diffhunk://#diff-ecc2e33c68f529075e70dee168d6567897b1902825ca94bef9bf27af10a476efL299-R317) [[2]](diffhunk://#diff-7047de02466f322e4777a220df0ba754b7a69490f0c218d51f6b90802bcd8771R130-R133) [[3]](diffhunk://#diff-7047de02466f322e4777a220df0ba754b7a69490f0c218d51f6b90802bcd8771L238-R243)