### PR TITLE
feat: add Privacy Policy and Terms of Use components with navigation in AppFooter

### DIFF
--- a/Frontend/src/App.jsx
+++ b/Frontend/src/App.jsx
@@ -18,6 +18,8 @@ import PublicProfileCard from './components/profile/PublicProfileCard';
 import HomeCard from './components/home/HomeCard';
 import GameCard from './components/game/GameCard';
 import api from './services/api';
+import PrivacyPolicyCard from './components/layout/PrivacyPolicyCard';
+import TermsOfUseCard from './components/layout/TermsOfUseCard';
 
 const avatarContext = require.context('./assets/profile', false, /\.(png|jpe?g|webp)$/);
 const avatarOptions = avatarContext
@@ -770,6 +772,12 @@ function App() {
     0
   );
 
+  const goToPrivacyPolicy = () => setView('privacyPolicy');
+  const goToTermsOfUse = () => setView('termsOfUse');
+
+  const isPrivacyPolicyView = view === 'privacyPolicy';
+  const isTermsOfUseView = view === 'termsOfUse';
+
   return (
     <div className="App">
       <div className="game-shell">
@@ -783,7 +791,7 @@ function App() {
           ) : isRegisterView ? (
             <RegisterHeader onGoToLogin={handleRegisterExit} />
           ) : isHomeView || isProfileEditView ? (
-              <HomeHeader
+            <HomeHeader
               initials={initials}
               profileImage={profile?.avatarUrl}
               welcomeName={profile?.nickname || profile?.name || 'Viajante'}
@@ -804,6 +812,30 @@ function App() {
                 goToHome();
               }}
             />
+          ) : isPrivacyPolicyView ? (
+            <>
+              <HomeHeader
+                initials={initials}
+                profileImage={profile?.avatarUrl}
+                welcomeName={profile?.nickname || profile?.name || 'Viajante'}
+                onGoToProfile={goToProfile}
+                onGoToEditProfile={goToEditProfile}
+                onLogout={handleLogout}
+              />
+              <PrivacyPolicyCard onBack={() => setView('home')} />
+            </>
+          ) : isTermsOfUseView ? (
+            <>
+              <HomeHeader
+                initials={initials}
+                profileImage={profile?.avatarUrl}
+                welcomeName={profile?.nickname || profile?.name || 'Viajante'}
+                onGoToProfile={goToProfile}
+                onGoToEditProfile={goToEditProfile}
+                onLogout={handleLogout}
+              />
+              <TermsOfUseCard onBack={() => setView('home')} />
+            </>
           ) : null}
 
           <main className={`App-main ${isGameView ? 'App-main-game' : ''} ${isProfileView ? 'App-main-profile' : ''} ${isEditProfileView ? 'App-main-profile' : ''}`}>
@@ -874,7 +906,7 @@ function App() {
             ) : null}
           </main>
 
-          {!isGameView && !isErrorView && !isProfileView && !isEditProfileView && <AppFooter />}
+          {!isGameView && !isErrorView && !isProfileView && !isEditProfileView && <AppFooter onGoToPrivacyPolicy={goToPrivacyPolicy} onGoToTermsOfUse={goToTermsOfUse}/>}
         </section>
       </div>
     </div>

--- a/Frontend/src/components/layout/AppFooter.jsx
+++ b/Frontend/src/components/layout/AppFooter.jsx
@@ -1,9 +1,25 @@
 import React from 'react';
 
-function AppFooter() {
+function AppFooter({ onGoToPrivacyPolicy, onGoToTermsOfUse }) {
   return (
-    <footer className="App-footer">
+    <footer className="App-footer" style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
       <p>Equipe TRANSCENDENCE: Bárbara, Carol, Luana e Thiago -- Todos os direitos reservados! </p>
+      <div style={{ display: 'flex', gap: '8px', alignItems: 'center', justifyContent: 'center' }}>
+        <button
+          type="button"
+          onClick={onGoToPrivacyPolicy}
+          style={{ background: 'none', border: '1px solid #fff', color: '#fff', padding: '4px 8px', cursor: 'pointer' }}
+        >
+          Política de Privacidade
+        </button>
+        <button
+          type="button"
+          onClick={onGoToTermsOfUse}
+          style={{ background: 'none', border: '1px solid #fff', color: '#fff', padding: '4px 8px', cursor: 'pointer' }}
+        >
+          Termos de Uso
+        </button>
+      </div>
     </footer>
   );
 }

--- a/Frontend/src/components/layout/EditHeader.jsx
+++ b/Frontend/src/components/layout/EditHeader.jsx
@@ -11,7 +11,7 @@ function EditHeader({ onGoToHome, onLogout }) {
       <div className="home-header-actions" aria-label="Acoes da edicao">
         <button
           type="button"
-          className="header-icon-button header-icon-button-edit"
+          className=""
           onClick={onGoToHome}
           aria-label="Ir para home"
           title="Ir para home"

--- a/Frontend/src/components/layout/PrivacyPolicyCard.jsx
+++ b/Frontend/src/components/layout/PrivacyPolicyCard.jsx
@@ -1,0 +1,121 @@
+import React from 'react';
+
+function PrivacyPolicyCard({ onBack }) {
+  return (
+    <section
+      className="card policy-card"
+      aria-label="Política de Privacidade"
+      style={{ margin: '0 auto' }}
+    >
+      <div className="policy-header" style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: '12px' }}>
+        <h1 style={{ margin: 0 }}>Política de Privacidade</h1>
+        <button
+          type="button"
+          className="header-icon-button"
+          onClick={onBack}
+          aria-label="Voltar"
+          title="Voltar"
+        >
+          ✕
+        </button>
+      </div>
+
+      <div className="policy-content">
+        <style>{`
+          .policy-content ul {
+            padding-left: 1.25rem;
+            list-style-position: outside;
+          }
+
+          .policy-content li {
+            margin-left: 0;
+          }
+        `}</style>
+            <p><strong>Última atualização: 09/05/2026</strong></p>
+
+        <h2>1. Quem somos</h2>
+        <p>
+          Este aplicativo é um jogo simples sobre aves migratórias brasileiras, com recursos de cadastro, login, interação entre usuários, perfil público e acompanhamento de partidas. Esta Política explica quais dados coletamos, como usamos e quais são seus direitos.
+        </p>
+
+        <h2>2. Dados que coletamos</h2>
+        <p>
+          Coletamos apenas os dados necessários para criar e operar a conta e as funcionalidades do jogo:
+        </p>
+        <ul>
+          <li>Email</li>
+          <li>Senha, armazenada de forma protegida e nunca exibida em texto puro</li>
+          <li>Nome de usuário / codinome</li>
+          <li>Quando aplicável, nome, bio, avatar e outras informações opcionais de perfil</li>
+          <li>Dados de autenticação via Google, quando o usuário opta por entrar com essa conta</li>
+          <li>Dados de uso do sistema, como ações de navegação, acesso a perfis, amizades, convites e partidas, quando necessários para o funcionamento do serviço</li>
+        </ul>
+
+        <h2>3. Como usamos os dados</h2>
+        <p>Usamos essas informações para:</p>
+        <ul>
+          <li>Criar e autenticar sua conta</li>
+          <li>Permitir login normal ou com Google</li>
+          <li>Exibir seu perfil e seu nome de usuário para outros jogadores</li>
+          <li>Viabilizar interações sociais, como convites de amizade e visualização de perfis</li>
+          <li>Registrar progresso, partidas, pontuações e demais funções do jogo</li>
+          <li>Prevenir abuso, fraude e uso indevido da plataforma</li>
+          <li>Cumprir obrigações legais, quando aplicável</li>
+        </ul>
+
+        <h2>4. Compartilhamento de dados</h2>
+        <p>
+          Não vendemos seus dados pessoais. Podemos compartilhar informações apenas nos seguintes casos:
+        </p>
+        <ul>
+          <li>Com serviços necessários para autenticação, como o provedor de login do Google</li>
+          <li>Com infraestrutura técnica usada para hospedar e manter o aplicativo</li>
+          <li>Quando exigido por lei, ordem judicial ou autoridade competente</li>
+          <li>Entre usuários da plataforma, apenas nas informações que são parte do funcionamento do app, como nome de usuário, perfil público, avatar e estatísticas visíveis</li>
+        </ul>
+
+        <h2>5. Login com Google</h2>
+        <p>
+          Se você escolher entrar com Google, receberemos os dados fornecidos por esse provedor para autenticação e criação ou associação da conta. Usamos apenas o necessário para identificar você e permitir acesso ao serviço.
+        </p>
+
+        <h2>6. Cookies e tecnologias similares</h2>
+        <p>
+          Podemos usar cookies ou armazenamento local apenas para manter sua sessão, lembrar preferências e permitir o funcionamento básico do sistema. Não usamos cookies para fins publicitários, a menos que isso seja informado futuramente.
+        </p>
+
+        <h2>7. Retenção e segurança</h2>
+        <p>
+          Mantemos seus dados enquanto sua conta existir ou enquanto forem necessários para o funcionamento do aplicativo. Adotamos medidas técnicas e organizacionais razoáveis para proteger as informações, mas nenhum sistema é completamente imune a riscos.
+        </p>
+
+        <h2>8. Seus direitos</h2>
+        <p>Você pode solicitar, conforme a legislação aplicável:</p>
+        <ul>
+          <li>Acesso aos seus dados</li>
+          <li>Correção de dados incompletos ou incorretos</li>
+          <li>Exclusão da conta e dos dados associados, quando possível</li>
+          <li>Informação sobre o uso e o tratamento dos seus dados</li>
+          <li>Revogação do consentimento, quando o tratamento depender dele</li>
+        </ul>
+
+        <h2>9. Menores de idade</h2>
+        <p>
+          Este serviço não é destinado a crianças sem supervisão adequada. Se houver uso por menor de idade, recomenda-se consentimento e acompanhamento de responsável legal, conforme a legislação local.
+        </p>
+
+        <h2>10. Alterações desta política</h2>
+        <p>
+          Podemos atualizar esta Política para refletir mudanças no aplicativo, na legislação ou em nossas práticas. A versão mais recente sempre estará disponível dentro da aplicação.
+        </p>
+
+        <h2>11. Contato</h2>
+        <p>
+          Se você tiver dúvidas sobre privacidade, entre em contato pelo canal informado na aplicação ou pelo email oficial do projeto, se disponível.
+        </p>
+      </div>
+    </section>
+  );
+}
+
+export default PrivacyPolicyCard;

--- a/Frontend/src/components/layout/TermsOfUseCard.jsx
+++ b/Frontend/src/components/layout/TermsOfUseCard.jsx
@@ -1,0 +1,135 @@
+import React from 'react';
+
+function TermsOfUseCard({ onBack }) {
+  return (
+    <section
+      className="card policy-card"
+      aria-label="Termos de Uso"
+      style={{ margin: '0 auto' }}
+    >
+      <div className="policy-header" style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: '12px' }}>
+        <h1 style={{ margin: 0 }}>Termos de Uso</h1>
+        <button
+          type="button"
+          className="header-icon-button"
+          onClick={onBack}
+          aria-label="Voltar"
+          title="Voltar"
+        >
+          ✕
+        </button>
+      </div>
+
+      <div className="policy-content">
+        <style>{`
+          .policy-content ul {
+            padding-left: 1.25rem;
+            list-style-position: outside;
+          }
+
+          .policy-content li {
+            margin-left: 0;
+          }
+        `}</style>
+        <p><em>Última atualização: 09/05/2026</em></p>
+
+        <h2>1. Aceitação dos termos</h2>
+        <p>
+          Ao criar uma conta, acessar ou usar este aplicativo, você concorda com estes Termos de Serviço
+          e com a Política de Privacidade. Se não concordar, não use o serviço.
+        </p>
+
+        <h2>2. Descrição do serviço</h2>
+        <p>
+          O aplicativo oferece um jogo simples sobre aves migratórias brasileiras, com cadastro de usuários,
+          autenticação por email e senha, login com Google, perfis públicos, interações sociais e recursos
+          ligados à experiência do jogo.
+        </p>
+
+        <h2>3. Conta de usuário</h2>
+        <p>Para usar o serviço, você deve:</p>
+        <ul>
+          <li>Fornecer informações verdadeiras e atualizadas</li>
+          <li>Manter sua senha em segurança</li>
+          <li>Não compartilhar sua conta com terceiros</li>
+          <li>Informar imediatamente qualquer uso não autorizado da sua conta</li>
+        </ul>
+
+        <h2>4. Regras de uso</h2>
+        <p>Você concorda em não usar o serviço para:</p>
+        <ul>
+          <li>Violentar a lei ou os direitos de terceiros</li>
+          <li>Fazer spam, assédio, abuso, fraude ou intimidação</li>
+          <li>Tentar invadir, explorar ou prejudicar a plataforma</li>
+          <li>Inserir conteúdo ofensivo, enganoso, discriminatório ou ilegal</li>
+          <li>Automatizar o uso do serviço de forma indevida</li>
+          <li>Tentar manipular pontuações, convites, amizades ou qualquer mecanismo do jogo</li>
+        </ul>
+
+        <h2>5. Interações entre usuários</h2>
+        <p>
+          O aplicativo pode permitir visualização de perfis, convites, amizades e outras interações. Você é
+          responsável pelo conteúdo que publica e pela forma como interage com outros usuários. Não use essas
+          funções para assédio ou comportamento inadequado.
+        </p>
+
+        <h2>6. Conteúdo e perfis</h2>
+        <p>
+          Informações públicas do perfil, como nome de usuário, avatar, bio e estatísticas, podem ser exibidas
+          para outros usuários conforme o funcionamento do serviço. Evite inserir dados sensíveis ou informações
+          que não deseja tornar visíveis.
+        </p>
+
+        <h2>7. Propriedade intelectual</h2>
+        <p>
+          Todo o design, marca, interface, textos, imagens e elementos do aplicativo pertencem aos seus
+          respectivos titulares, salvo indicação contrária. Você recebe apenas uma licença limitada para uso
+          do serviço conforme estes Termos.
+        </p>
+
+        <h2>8. Disponibilidade do serviço</h2>
+        <p>
+          O serviço é oferecido “como está” e pode ser alterado, suspenso ou encerrado a qualquer momento,
+          total ou parcialmente, por motivos técnicos, de manutenção ou de segurança.
+        </p>
+
+        <h2>9. Suspensão e encerramento de conta</h2>
+        <p>
+          Podemos limitar, suspender ou encerrar contas que violem estes Termos, prejudiquem outros usuários
+          ou comprometam o funcionamento do sistema.
+        </p>
+
+        <h2>10. Isenção de garantias</h2>
+        <p>
+          Não garantimos funcionamento ininterrupto, livre de erros ou totalmente seguro. Embora o serviço seja
+          mantido com cuidado, falhas podem ocorrer.
+        </p>
+
+        <h2>11. Limitação de responsabilidade</h2>
+        <p>
+          Na máxima extensão permitida pela lei, não nos responsabilizamos por danos indiretos, perda de dados,
+          interrupções de serviço ou prejuízos causados por uso indevido da plataforma ou por fatores fora do
+          nosso controle.
+        </p>
+
+        <h2>12. Alterações dos termos</h2>
+        <p>
+          Podemos atualizar estes Termos a qualquer momento. Se as mudanças forem relevantes, elas devem ser
+          disponibilizadas dentro da aplicação. O uso contínuo após a atualização indica concordância com a
+          nova versão.
+        </p>
+
+        <h2>13. Lei aplicável e foro</h2>
+        <p>
+          Estes Termos serão regidos pela legislação aplicável ao projeto e, quando necessário, eventuais disputas
+          serão resolvidas no foro competente.
+        </p>
+
+        <h2>14. Contato</h2>
+        <p>Dúvidas sobre estes Termos podem ser enviadas pelo canal oficial informado na aplicação.</p>
+      </div>
+    </section>
+  );
+}
+
+export default TermsOfUseCard;


### PR DESCRIPTION
feat: add Privacy Policy and Terms of Use components with navigation in AppFooter
This pull request adds dedicated Privacy Policy and Terms of Use views to the application, making these documents easily accessible from the app footer. It introduces two new components for displaying the content of each policy, updates the footer to include navigation buttons, and adjusts the main app logic to handle these new views.

**New policy views and navigation:**

* Added `PrivacyPolicyCard` and `TermsOfUseCard` components to display the privacy policy and terms of use within the app. [[1]](diffhunk://#diff-23428568e719ffe8d979c8244c4346f99cdd58473b0298f92bd3afefc7e27a12R1-R121) [[2]](diffhunk://#diff-f5ea7ad7ee680ea6f94cb978193d6eb773ea6a04755dba1d80a1ff2377d77feeR1-R135)
* Updated `App.jsx` to support navigation to the new policy views, including state management and conditional rendering for these sections. [[1]](diffhunk://#diff-ecc2e33c68f529075e70dee168d6567897b1902825ca94bef9bf27af10a476efR21-R22) [[2]](diffhunk://#diff-ecc2e33c68f529075e70dee168d6567897b1902825ca94bef9bf27af10a476efR775-R780) [[3]](diffhunk://#diff-ecc2e33c68f529075e70dee168d6567897b1902825ca94bef9bf27af10a476efR815-R838)

**Footer and navigation improvements:**

* Modified `AppFooter` to include buttons for opening the Privacy Policy and Terms of Use, and passed the appropriate navigation handlers from `App.jsx`. [[1]](diffhunk://#diff-cef84ad830bc8d1b1d29a932d08718e3a1acbd2e303b631e131755f89dc7bc22L3-R22) [[2]](diffhunk://#diff-ecc2e33c68f529075e70dee168d6567897b1902825ca94bef9bf27af10a476efL877-R909)

**Minor UI adjustment:**

* Removed an unused CSS class from a button in `EditHeader.jsx` for cleaner markup.