### PR TITLE
fix: corrigir caminho do script de geração de keystore no Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ CERT_FILE= ./Backend/certs/keystore-dev.p12
 cert:
 	@if [ ! -f $(CERT_FILE) ]; then \
 		echo ">> Gerando keystore..."; \
-		KEYSTORE_PASSWORD=changeit ./certs/generate-keystore.sh dev; \
+		KEYSTORE_PASSWORD=changeit ./Backend/certs/generate-keystore.sh dev; \
 	else \
 		echo ">> Keystore já existe"; \
 	fi


### PR DESCRIPTION
This pull request makes a small but important fix to the `Makefile` by correcting the path to the `generate-keystore.sh` script. The script is now referenced from the correct location within the `Backend/certs` directory.