### PR TITLE
feat: add Prometheus alerting rules and update configuration

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -99,6 +99,7 @@ services:
       - "9090:9090"
     volumes:
       - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - ./monitoring/prometheus-rules.yml:/etc/prometheus/prometheus-rules.yml:ro
       - prometheus_data_dev:/prometheus
     command:
       - '--config.file=/etc/prometheus/prometheus.yml'

--- a/monitoring/grafana/provisioning/datasources/prometheus.yml
+++ b/monitoring/grafana/provisioning/datasources/prometheus.yml
@@ -1,5 +1,7 @@
 apiVersion: 1
 
+
+
 datasources:
   - name: Prometheus
     type: prometheus

--- a/monitoring/prometheus-rules.yml
+++ b/monitoring/prometheus-rules.yml
@@ -1,0 +1,39 @@
+groups:
+  - name: memory_alerts
+    interval: 15s
+    rules:
+      - alert: HighMemoryUsage
+        expr: (1 - (node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes)) * 100 > 50
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Uso de memória moderado detectado"
+          description: "O consumo de memória está acima de 50% (valor atual: {{ $value | humanize }}%) no host {{ $labels.instance }}"
+
+      - alert: CriticalMemoryUsage
+        expr: (1 - (node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes)) * 100 > 80
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Uso crítico de memória detectado"
+          description: "O consumo de memória está acima de 80% (valor atual: {{ $value | humanize }}%) no host {{ $labels.instance }}"
+
+      - alert: HighCPUUsage
+        expr: (100 - (avg by (instance) (rate(node_cpu_seconds_total{mode="idle"}[5m])) * 100)) > 80
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Alto uso de CPU detectado"
+          description: "O consumo de CPU está acima de 80% (valor atual: {{ $value | humanize }}%) no host {{ $labels.instance }}"
+
+      - alert: DiskSpaceLow
+        expr: (node_filesystem_avail_bytes{fstype!~"tmpfs|fuse.lowerfs|squashfs|vfat"} / node_filesystem_size_bytes) * 100 < 15
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Espaço em disco baixo"
+          description: "Espaço disponível em disco está abaixo de 15% (valor atual: {{ $value | humanize }}%) no host {{ $labels.instance }} - dispositivo: {{ $labels.device }}"

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -4,6 +4,9 @@ global:
   external_labels:
     monitor: 'transcendence-monitor'
 
+rule_files:
+  - '/etc/prometheus/prometheus-rules.yml'
+
 scrape_configs:
   # Application metrics (Spring Boot Actuator)
   - job_name: 'spring-boot-app'


### PR DESCRIPTION
This pull request introduces monitoring improvements by adding custom Prometheus alerting rules and ensuring they are properly integrated into the development environment. The changes enable Prometheus to trigger alerts for high memory usage, critical memory usage, high CPU usage, and low disk space, and make these rules available to the running Prometheus container.

Prometheus alerting configuration:

* Added a new file, `monitoring/prometheus-rules.yml`, containing alerting rules for memory usage, CPU usage, and disk space. These rules will trigger warnings and critical alerts based on resource thresholds.
* Updated `prometheus.yml` to include the new `prometheus-rules.yml` file in the `rule_files` section, ensuring Prometheus loads these custom alert rules.
* Modified the `docker-compose.dev.yml` configuration to mount `prometheus-rules.yml` into the Prometheus container, making the rules available at runtime.

Grafana provisioning:

* Minor formatting change in `monitoring/grafana/provisioning/datasources/prometheus.yml` (no functional impact).